### PR TITLE
Add Transform() method to CoordinateTransform struct

### DIFF
--- a/osr.go
+++ b/osr.go
@@ -1188,6 +1188,11 @@ func (ct CoordinateTransform) Destroy() {
 	C.OCTDestroyCoordinateTransformation(ct.cval)
 }
 
+func (ct CoordinateTransform) Transform(numPoints int, xPoints []float64, yPoints []float64, zPoints []float64) bool {
+	val := C.OCTTransform(ct.cval, C.int(numPoints), (*C.double)(unsafe.Pointer(&xPoints[0])), (*C.double)(unsafe.Pointer(&yPoints[0])), (*C.double)(unsafe.Pointer(&zPoints[0])))
+	return int(val) != 0
+}
+
 // Fetch list of possible projection methods
 func ProjectionMethods() []string {
 	p := C.OPTGetProjectionMethods()


### PR DESCRIPTION
Fills in a missing method in the CoordinateTransform section of the library.