### PR TITLE
GIntBig => long

### DIFF
--- a/ogr.go
+++ b/ogr.go
@@ -1249,7 +1249,7 @@ func (feature Feature) FID() int {
 
 // Set feature identifier
 func (feature Feature) SetFID(fid int) error {
-	return C.OGR_F_SetFID(feature.cval, C.GIntBig(fid)).Err()
+	return C.OGR_F_SetFID(feature.cval, C.long(fid)).Err()
 }
 
 // Unimplemented: DumpReadable
@@ -1340,12 +1340,12 @@ func (layer Layer) NextFeature() Feature {
 
 // Move read cursor to the provided index
 func (layer Layer) SetNextByIndex(index int) error {
-	return C.OGR_L_SetNextByIndex(layer.cval, C.GIntBig(index)).Err()
+	return C.OGR_L_SetNextByIndex(layer.cval, C.long(index)).Err()
 }
 
 // Fetch a feature by its index
 func (layer Layer) Feature(index int) Feature {
-	feature := C.OGR_L_GetFeature(layer.cval, C.GIntBig(index))
+	feature := C.OGR_L_GetFeature(layer.cval, C.long(index))
 	return Feature{feature}
 }
 
@@ -1361,7 +1361,7 @@ func (layer Layer) Create(feature Feature) error {
 
 // Delete indicated feature from layer
 func (layer Layer) Delete(index int) error {
-	return C.OGR_L_DeleteFeature(layer.cval, C.GIntBig(index)).Err()
+	return C.OGR_L_DeleteFeature(layer.cval, C.long(index)).Err()
 }
 
 // Fetch the schema information for this layer


### PR DESCRIPTION
Installing on OS X. gdal installed with brew

```
gdal git:(master) brew info gdal
gdal: stable 1.11.3 (bottled), HEAD
GDAL: Geospatial Data Abstraction Library
http://www.gdal.org/
/usr/local/Cellar/gdal/1.11.2_3 (230 files, 32.0M) *
  Poured from bottle
From: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/gdal.rb
==> Dependencies
Required: libpng ✘, jpeg ✔, giflib ✔, libtiff ✘, libgeotiff ✔, proj ✘, geos ✘, sqlite ✘, freexl ✔, libspatialite ✘
Optional: postgresql ✘, mysql ✘
==> Options
--with-armadillo
    Build with Armadillo accelerated TPS transforms.
--with-complete
    Use additional Homebrew libraries to provide more drivers.
--with-java
    Build with java support
--with-libkml
    Build with Google's libkml driver (requires libkml --HEAD or >= 1.3)
--with-mdb
    Build with Access MDB driver (requires Java 1.6+ JDK/JRE, from Apple or Oracle).
--with-mysql
    Build with mysql support
--with-opencl
    Build with OpenCL acceleration.
--with-postgresql
    Build with postgresql support
--with-python3
    Build with python3 support
--with-swig-java
    Build the swig java bindings
--with-unsupported
    Allow configure to drag in any library it can find. Invoke this at your own risk.
--without-python
    Build without python2 support
--HEAD
    Install HEAD version
```

Got

```
go get github.com/lukeroth/gdal
# github.com/lukeroth/gdal
../../../lukeroth/gdal/ogr.go:1252: cannot use C.GIntBig(fid) (type C.GIntBig) as type C.long in argument to _Cfunc_OGR_F_SetFID
../../../lukeroth/gdal/ogr.go:1343: cannot use C.GIntBig(index) (type C.GIntBig) as type C.long in argument to _Cfunc_OGR_L_SetNextByIndex
../../../lukeroth/gdal/ogr.go:1348: cannot use C.GIntBig(index) (type C.GIntBig) as type C.long in argument to _Cfunc_OGR_L_GetFeature
../../../lukeroth/gdal/ogr.go:1364: cannot use C.GIntBig(index) (type C.GIntBig) as type C.long in argument to _Cfunc_OGR_L_DeleteFeature
```
