### PR TITLE
Fix gdal import path

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -17,7 +17,7 @@ A simple program to create a georeferenced blank 256x256 GeoTIFF:
 	import (
 		"fmt"
 		"flag"
-		gdal "github.com/lukeroth/gdal_go"
+		gdal "github.com/lukeroth/gdal"
 	)
 
 	func main() {


### PR DESCRIPTION
The example given has wrong import path as "gdal_go" instead of "gdal".