### PR TITLE
Prevent panic on missing metadata

### DIFF
--- a/gdal.go
+++ b/gdal.go
@@ -667,7 +667,7 @@ func (dataset *Dataset) Metadata(domain string) []string {
 	q := uintptr(unsafe.Pointer(p))
 	for {
 		p = (**C.char)(unsafe.Pointer(q))
-		if *p == nil {
+		if p == nil {
 			break
 		}
 		strings = append(strings, C.GoString(*p))

--- a/gdal_test.go
+++ b/gdal_test.go
@@ -4,11 +4,25 @@
 
 package gdal
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestTiffDriver(t *testing.T) {
 	_, err := GetDriverByName("GTiff")
 	if err != nil {
 		t.Errorf(err.Error())
+	}
+}
+
+func TestMissingMetadata(t *testing.T) {
+	ds, err := Open("testdata/tiles.gpkg", ReadOnly)
+	if err != nil {
+		t.Fatalf("failed to open test file: %v", err)
+	}
+
+	metadata := ds.Metadata("something-that-wont-exist")
+	if len(metadata) != 0 {
+		t.Errorf("got %d items, want 0", len(metadata))
 	}
 }


### PR DESCRIPTION
`dataset.Metadata` currently panics when given a domain that doesn't exist. This makes it return an empty list instead, which appears to be what was intended.