### PR TITLE
removed methods that are no longer supported in 3.x versions of GDAL

### DIFF
--- a/ogr.go
+++ b/ogr.go
@@ -1282,7 +1282,7 @@ func (feature Feature) SetFieldBinary(index int, value []uint8) {
         feature.cval,
         C.int(index),
         C.int(len(value)),
-        (*C.GByte)(unsafe.Pointer(&value[0])),
+        unsafe.Pointer(&value[0]),
     )
 }
 


### PR DESCRIPTION
Removed references to methods no longer supported in GDAL 3.x. Recommend pinning the version of this library to the version of the underling gdal library.