### PR TITLE
Fixes darwin,amd64 compilation against Homebrew GDAL on Catalina

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ examples/translate/translate
 examples/warp/warp
 examples/grid/grid
 .idea
+*.iml

--- a/c_darwin_amd64.go
+++ b/c_darwin_amd64.go
@@ -1,0 +1,9 @@
+// +build darwin,amd64
+
+package gdal
+
+/*
+#cgo pkg-config: gdal
+#cgo LDFLAGS: -Wl,-undefined,dynamic_lookup
+*/
+import "C"

--- a/c_linux_amd64.go
+++ b/c_linux_amd64.go
@@ -1,4 +1,4 @@
-// +build linux,amd64 darwin,amd64
+// +build linux,amd64
 
 package gdal
 

--- a/gdal.go
+++ b/gdal.go
@@ -681,7 +681,7 @@ func (dataset *Dataset) Metadata(domain string) []string {
 	q := uintptr(unsafe.Pointer(p))
 	for {
 		p = (**C.char)(unsafe.Pointer(q))
-		if p == nil {
+		if p == nil || *p == nil {
 			break
 		}
 		strings = append(strings, C.GoString(*p))


### PR DESCRIPTION
Overrides the default (error) behavior for undefined symbols for OSX with dynamic lookup.