### PR TITLE
Err() function causing error: cannot define new methods on non-local type C.OGRErr & C.CPLErr

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -90,13 +90,14 @@ func (src RasterBand) ComputeProximity(
 	}
 	opts[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return CPLErr(C.GDALComputeProximity(
+	cErr := C.GDALComputeProximity(
 		src.cval,
 		dest.cval,
 		(**C.char)(unsafe.Pointer(&opts[0])),
 		C.goGDALProgressFuncProxyB(),
 		unsafe.Pointer(arg),
-	)).Err()
+	)
+	return CPLErrContainer{ErrVal: cErr}.Err()
 }
 
 // Fill selected raster regions by interpolation from the edges
@@ -120,7 +121,7 @@ func (src RasterBand) FillNoData(
 	}
 	opts[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return CPLErr(C.GDALFillNodata(
+	cErr := C.GDALFillNodata(
 		src.cval,
 		mask.cval,
 		C.double(distance),
@@ -129,7 +130,8 @@ func (src RasterBand) FillNoData(
 		(**C.char)(unsafe.Pointer(&opts[0])),
 		C.goGDALProgressFuncProxyB(),
 		unsafe.Pointer(arg),
-	)).Err()
+	)
+	return CPLErrContainer{ErrVal: cErr}.Err()
 }
 
 // Create polygon coverage from raster data using an integer buffer
@@ -153,7 +155,7 @@ func (src RasterBand) Polygonize(
 	}
 	opts[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return CPLErr(C.GDALPolygonize(
+	cErr := C.GDALPolygonize(
 		src.cval,
 		mask.cval,
 		layer.cval,
@@ -161,7 +163,8 @@ func (src RasterBand) Polygonize(
 		(**C.char)(unsafe.Pointer(&opts[0])),
 		C.goGDALProgressFuncProxyB(),
 		unsafe.Pointer(arg),
-	)).Err()
+	)
+	return CPLErrContainer{ErrVal: cErr}.Err()
 }
 
 // Create polygon coverage from raster data using a floating point buffer
@@ -185,7 +188,7 @@ func (src RasterBand) FPolygonize(
 	}
 	opts[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return CPLErr(C.GDALFPolygonize(
+	cErr := C.GDALFPolygonize(
 		src.cval,
 		mask.cval,
 		layer.cval,
@@ -193,7 +196,8 @@ func (src RasterBand) FPolygonize(
 		(**C.char)(unsafe.Pointer(&opts[0])),
 		C.goGDALProgressFuncProxyB(),
 		unsafe.Pointer(arg),
-	)).Err()
+	)
+	return CPLErrContainer{ErrVal: cErr}.Err()
 }
 
 // Removes small raster polygons
@@ -216,7 +220,7 @@ func (src RasterBand) SieveFilter(
 	}
 	opts[length] = (*C.char)(unsafe.Pointer(nil))
 
-	return CPLErr(C.GDALSieveFilter(
+	cErr := C.GDALSieveFilter(
 		src.cval,
 		mask.cval,
 		dest.cval,
@@ -225,7 +229,8 @@ func (src RasterBand) SieveFilter(
 		(**C.char)(unsafe.Pointer(&opts[0])),
 		C.goGDALProgressFuncProxyB(),
 		unsafe.Pointer(arg),
-	)).Err()
+	)
+	return CPLErrContainer{ErrVal: cErr}.Err()
 }
 
 /* --------------------------------------------- */
@@ -301,7 +306,6 @@ func (src RasterBand) SieveFilter(
 // GridAlgorithm represents Grid Algorithm code
 type GridAlgorithm int
 
-//
 const (
 	GA_InverseDistancetoAPower                = GridAlgorithm(C.GGA_InverseDistanceToAPower)
 	GA_MovingAverage                          = GridAlgorithm(C.GGA_MovingAverage)
@@ -454,7 +458,7 @@ func GridCreate(
 			return nil, errInvalidOptionsTypeWasPassed
 		}
 		poptions = unsafe.Pointer(&C.GDALGridInverseDistanceToAPowerOptions{
-			nSizeOfStructure: C.size_t(unsafe.Sizeof(soptions)),
+			nSizeOfStructure:  C.size_t(unsafe.Sizeof(soptions)),
 			dfPower:           C.double(soptions.Power),
 			dfSmoothing:       C.double(soptions.Smoothing),
 			dfAnisotropyRatio: C.double(soptions.AnisotropyRatio),
@@ -473,12 +477,12 @@ func GridCreate(
 		}
 		poptions = unsafe.Pointer(&C.GDALGridInverseDistanceToAPowerNearestNeighborOptions{
 			nSizeOfStructure: C.size_t(unsafe.Sizeof(soptions)),
-			dfPower:       C.double(soptions.Power),
-			dfRadius:      C.double(soptions.Radius),
-			dfSmoothing:   C.double(soptions.Smoothing),
-			nMaxPoints:    C.uint(soptions.MaxPoints),
-			nMinPoints:    C.uint(soptions.MinPoints),
-			dfNoDataValue: C.double(soptions.NoDataValue),
+			dfPower:          C.double(soptions.Power),
+			dfRadius:         C.double(soptions.Radius),
+			dfSmoothing:      C.double(soptions.Smoothing),
+			nMaxPoints:       C.uint(soptions.MaxPoints),
+			nMinPoints:       C.uint(soptions.MinPoints),
+			dfNoDataValue:    C.double(soptions.NoDataValue),
 		})
 	case GA_MovingAverage:
 		soptions, ok := options.(GridMovingAverageOptions)
@@ -487,11 +491,11 @@ func GridCreate(
 		}
 		poptions = unsafe.Pointer(&C.GDALGridMovingAverageOptions{
 			nSizeOfStructure: C.size_t(unsafe.Sizeof(soptions)),
-			dfRadius1:     C.double(soptions.Radius1),
-			dfRadius2:     C.double(soptions.Radius2),
-			dfAngle:       C.double(soptions.Angle),
-			nMinPoints:    C.uint(soptions.MinPoints),
-			dfNoDataValue: C.double(soptions.NoDataValue),
+			dfRadius1:        C.double(soptions.Radius1),
+			dfRadius2:        C.double(soptions.Radius2),
+			dfAngle:          C.double(soptions.Angle),
+			nMinPoints:       C.uint(soptions.MinPoints),
+			dfNoDataValue:    C.double(soptions.NoDataValue),
 		})
 	case GA_NearestNeighbor:
 		soptions, ok := options.(GridNearestNeighborOptions)
@@ -500,10 +504,10 @@ func GridCreate(
 		}
 		poptions = unsafe.Pointer(&C.GDALGridNearestNeighborOptions{
 			nSizeOfStructure: C.size_t(unsafe.Sizeof(soptions)),
-			dfRadius1:     C.double(soptions.Radius1),
-			dfRadius2:     C.double(soptions.Radius2),
-			dfAngle:       C.double(soptions.Angle),
-			dfNoDataValue: C.double(soptions.NoDataValue),
+			dfRadius1:        C.double(soptions.Radius1),
+			dfRadius2:        C.double(soptions.Radius2),
+			dfAngle:          C.double(soptions.Angle),
+			dfNoDataValue:    C.double(soptions.NoDataValue),
 		})
 	case GA_MetricMinimum, GA_MetricMaximum, GA_MetricCount, GA_MetricRange,
 		GA_MetricAverageDistance, GA_MetricAverageDistancePts:
@@ -513,11 +517,11 @@ func GridCreate(
 		}
 		poptions = unsafe.Pointer(&C.GDALGridDataMetricsOptions{
 			nSizeOfStructure: C.size_t(unsafe.Sizeof(soptions)),
-			dfRadius1:     C.double(soptions.Radius1),
-			dfRadius2:     C.double(soptions.Radius2),
-			dfAngle:       C.double(soptions.Angle),
-			nMinPoints:    C.uint(soptions.MinPoints),
-			dfNoDataValue: C.double(soptions.NoDataValue),
+			dfRadius1:        C.double(soptions.Radius1),
+			dfRadius2:        C.double(soptions.Radius2),
+			dfAngle:          C.double(soptions.Angle),
+			nMinPoints:       C.uint(soptions.MinPoints),
+			dfNoDataValue:    C.double(soptions.NoDataValue),
 		})
 	case GA_Linear:
 		soptions, ok := options.(GridLinearOptions)
@@ -526,14 +530,14 @@ func GridCreate(
 		}
 		poptions = unsafe.Pointer(&C.GDALGridLinearOptions{
 			nSizeOfStructure: C.size_t(unsafe.Sizeof(soptions)),
-			dfRadius:      C.double(soptions.Radius),
-			dfNoDataValue: C.double(soptions.NoDataValue),
+			dfRadius:         C.double(soptions.Radius),
+			dfNoDataValue:    C.double(soptions.NoDataValue),
 		})
 	}
 
 	buffer := make([]float64, nX*nY)
 	arg := &goGDALProgressFuncProxyArgs{progress, data}
-	err := CPLErr(C.GDALGridCreate(
+	cErr := C.GDALGridCreate(
 		C.GDALGridAlgorithm(algorithm),
 		poptions,
 		C.uint(uint(len(x))),
@@ -550,8 +554,8 @@ func GridCreate(
 		unsafe.Pointer(&buffer[0]),
 		C.goGDALProgressFuncProxyB(),
 		unsafe.Pointer(arg),
-	)).Err()
-	return buffer, err
+	)
+	return buffer, CPLErrContainer{ErrVal: cErr}.Err()
 }
 
 //Unimplemented: ComputeMatchingPoints

--- a/osr.go
+++ b/osr.go
@@ -43,13 +43,15 @@ func (sr SpatialReference) SetAxisMappingStrategy(strategy AxisMappingStrategy) 
 func (sr SpatialReference) FromWKT(wkt string) error {
 	cString := C.CString(wkt)
 	defer C.free(unsafe.Pointer(cString))
-	return OGRErr(C.OSRImportFromWkt(sr.cval, &cString)).Err()
+	cErr := C.OSRImportFromWkt(sr.cval, &cString)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Export coordinate system to WKT
 func (sr SpatialReference) ToWKT() (string, error) {
 	var p *C.char
-	err := OGRErr(C.OSRExportToWkt(sr.cval, &p)).Err()
+	cErr := C.OSRExportToWkt(sr.cval, &p)
+	err := OGRErrContainer{ErrVal: cErr}.Err()
 	wkt := C.GoString(p)
 	return wkt, err
 }
@@ -57,21 +59,24 @@ func (sr SpatialReference) ToWKT() (string, error) {
 // Export coordinate system to a nicely formatted WKT string
 func (sr SpatialReference) ToPrettyWKT(simplify bool) (string, error) {
 	var p *C.char
-	err := OGRErr(C.OSRExportToPrettyWkt(
+	cErr := C.OSRExportToPrettyWkt(
 		sr.cval, &p, BoolToCInt(simplify),
-	)).Err()
+	)
+	err := OGRErrContainer{ErrVal: cErr}.Err()
 	wkt := C.GoString(p)
 	return wkt, err
 }
 
 // Initialize SRS based on EPSG code
 func (sr SpatialReference) FromEPSG(code int) error {
-	return OGRErr(C.OSRImportFromEPSG(sr.cval, C.int(code))).Err()
+	cErr := C.OSRImportFromEPSG(sr.cval, C.int(code))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Initialize SRS based on EPSG code, using EPSG lat/long ordering
 func (sr SpatialReference) FromEPSGA(code int) error {
-	return OGRErr(C.OSRImportFromEPSGA(sr.cval, C.int(code))).Err()
+	cErr := C.OSRImportFromEPSGA(sr.cval, C.int(code))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Destroy the spatial reference
@@ -110,20 +115,23 @@ func (sr SpatialReference) Release() {
 
 // Validate spatial reference tokens
 func (sr SpatialReference) Validate() error {
-	return OGRErr(C.OSRValidate(sr.cval)).Err()
+	cErr := C.OSRValidate(sr.cval)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Import PROJ.4 coordinate string
 func (sr SpatialReference) FromProj4(input string) error {
 	cString := C.CString(input)
 	defer C.free(unsafe.Pointer(cString))
-	return OGRErr(C.OSRImportFromProj4(sr.cval, cString)).Err()
+	cErr := C.OSRImportFromProj4(sr.cval, cString)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Export coordinate system in PROJ.4 format
 func (sr SpatialReference) ToProj4() (string, error) {
 	var p *C.char
-	err := OGRErr(C.OSRExportToProj4(sr.cval, &p)).Err()
+	cErr := C.OSRExportToProj4(sr.cval, &p)
+	err := OGRErrContainer{ErrVal: cErr}.Err()
 	proj4 := C.GoString(p)
 	return proj4, err
 }
@@ -132,7 +140,8 @@ func (sr SpatialReference) ToProj4() (string, error) {
 func (sr SpatialReference) FromESRI(input string) error {
 	cString := C.CString(input)
 	defer C.free(unsafe.Pointer(cString))
-	return OGRErr(C.OSRImportFromProj4(sr.cval, cString)).Err()
+	cErr := C.OSRImportFromProj4(sr.cval, cString)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Import coordinate system from PCI projection definition
@@ -142,30 +151,33 @@ func (sr SpatialReference) FromPCI(proj, units string, params []float64) error {
 	cUnits := C.CString(units)
 	defer C.free(unsafe.Pointer(cUnits))
 
-	return OGRErr(C.OSRImportFromPCI(
+	cErr := C.OSRImportFromPCI(
 		sr.cval,
 		cProj,
 		cUnits,
 		(*C.double)(unsafe.Pointer(&params[0])),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Import coordinate system from USGS projection definition
 func (sr SpatialReference) FromUSGS(projsys, zone int, params []float64, datum int) error {
-	return OGRErr(C.OSRImportFromUSGS(
+	cErr := C.OSRImportFromUSGS(
 		sr.cval,
 		C.long(projsys),
 		C.long(zone),
 		(*C.double)(unsafe.Pointer(&params[0])),
 		C.long(datum),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Import coordinate system from XML format (GML only currently)
 func (sr SpatialReference) FromXML(xml string) error {
 	cXml := C.CString(xml)
 	defer C.free(unsafe.Pointer(cXml))
-	return OGRErr(C.OSRImportFromXML(sr.cval, cXml)).Err()
+	cErr := C.OSRImportFromXML(sr.cval, cXml)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Import coordinate system from ERMapper projection definitions
@@ -177,22 +189,25 @@ func (sr SpatialReference) FromERM(proj, datum, units string) error {
 	cUnits := C.CString(units)
 	defer C.free(unsafe.Pointer(cUnits))
 
-	return OGRErr(C.OSRImportFromERM(sr.cval, cProj, cDatum, cUnits)).Err()
+	cErr := C.OSRImportFromERM(sr.cval, cProj, cDatum, cUnits)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Import coordinate system from a URL
 func (sr SpatialReference) FromURL(url string) error {
 	cURL := C.CString(url)
 	defer C.free(unsafe.Pointer(cURL))
-	return OGRErr(C.OSRImportFromXML(sr.cval, cURL)).Err()
+	cErr := C.OSRImportFromXML(sr.cval, cURL)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Export coordinate system in PCI format
 func (sr SpatialReference) ToPCI() (proj, units string, params []float64, errVal error) {
 	var p, u *C.char
-	err := OGRErr(C.OSRExportToPCI(
+	cErr := C.OSRExportToPCI(
 		sr.cval, &p, &u, (**C.double)(unsafe.Pointer(&params[0])),
-	)).Err()
+	)
+	err := OGRErrContainer{ErrVal: cErr}.Err()
 	header := (*reflect.SliceHeader)(unsafe.Pointer(&params))
 	header.Cap = 17
 	header.Len = 17
@@ -203,13 +218,14 @@ func (sr SpatialReference) ToPCI() (proj, units string, params []float64, errVal
 
 // Export coordinate system to USGS GCTP projection definition
 func (sr SpatialReference) ToUSGS() (proj, zone int, params []float64, datum int, errVal error) {
-	err := OGRErr(C.OSRExportToUSGS(
+	cErr := C.OSRExportToUSGS(
 		sr.cval,
 		(*C.long)(unsafe.Pointer(&proj)),
 		(*C.long)(unsafe.Pointer(&zone)),
 		(**C.double)(unsafe.Pointer(&params[0])),
 		(*C.long)(unsafe.Pointer(&datum)),
-	)).Err()
+	)
+	err := OGRErrContainer{ErrVal: cErr}.Err()
 
 	header := (*reflect.SliceHeader)(unsafe.Pointer(&params))
 	header.Cap = 15
@@ -221,7 +237,8 @@ func (sr SpatialReference) ToUSGS() (proj, zone int, params []float64, datum int
 // Export coordinate system in XML format
 func (sr SpatialReference) ToXML() (xml string, errVal error) {
 	var x *C.char
-	err := OGRErr(C.OSRExportToXML(sr.cval, &x, nil)).Err()
+	cErr := C.OSRExportToXML(sr.cval, &x, nil)
+	err := OGRErrContainer{ErrVal: cErr}.Err()
 	defer C.free(unsafe.Pointer(x))
 	return C.GoString(x), err
 }
@@ -229,7 +246,8 @@ func (sr SpatialReference) ToXML() (xml string, errVal error) {
 // Export coordinate system in Mapinfo style CoordSys format
 func (sr SpatialReference) ToMICoordSys() (output string, errVal error) {
 	var x *C.char
-	err := OGRErr(C.OSRExportToMICoordSys(sr.cval, &x)).Err()
+	cErr := C.OSRExportToMICoordSys(sr.cval, &x)
+	err := OGRErrContainer{ErrVal: cErr}.Err()
 	defer C.free(unsafe.Pointer(x))
 	return C.GoString(x), err
 }
@@ -239,12 +257,14 @@ func (sr SpatialReference) ToMICoordSys() (output string, errVal error) {
 
 // Convert in place to ESRI WKT format
 func (sr SpatialReference) MorphToESRI() error {
-	return OGRErr(C.OSRMorphToESRI(sr.cval)).Err()
+	cErr := C.OSRMorphToESRI(sr.cval)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Convert in place from ESRI WKT format
 func (sr SpatialReference) MorphFromESRI() error {
-	return OGRErr(C.OSRMorphFromESRI(sr.cval)).Err()
+	cErr := C.OSRMorphFromESRI(sr.cval)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Fetch indicated attribute of named node
@@ -261,14 +281,16 @@ func (sr SpatialReference) SetAttrValue(path, value string) error {
 	defer C.free(unsafe.Pointer(cPath))
 	cValue := C.CString(value)
 	defer C.free(unsafe.Pointer(cValue))
-	return OGRErr(C.OSRSetAttrValue(sr.cval, cPath, cValue)).Err()
+	cErr := C.OSRSetAttrValue(sr.cval, cPath, cValue)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set the angular units for the geographic coordinate system
 func (sr SpatialReference) SetAngularUnits(units string, radians float64) error {
 	cUnits := C.CString(units)
 	defer C.free(unsafe.Pointer(cUnits))
-	return OGRErr(C.OSRSetAngularUnits(sr.cval, cUnits, C.double(radians))).Err()
+	cErr := C.OSRSetAngularUnits(sr.cval, cUnits, C.double(radians))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Fetch the angular units for the geographic coordinate system
@@ -283,7 +305,8 @@ func (sr SpatialReference) AngularUnits() (string, float64) {
 func (sr SpatialReference) SetLinearUnits(name string, toMeters float64) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetLinearUnits(sr.cval, cName, C.double(toMeters))).Err()
+	cErr := C.OSRSetLinearUnits(sr.cval, cName, C.double(toMeters))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set the linear units for the target node
@@ -292,14 +315,16 @@ func (sr SpatialReference) SetTargetLinearUnits(target, units string, toMeters f
 	defer C.free(unsafe.Pointer(cTarget))
 	cUnits := C.CString(units)
 	defer C.free(unsafe.Pointer(cUnits))
-	return OGRErr(C.OSRSetTargetLinearUnits(sr.cval, cTarget, cUnits, C.double(toMeters))).Err()
+	cErr := C.OSRSetTargetLinearUnits(sr.cval, cTarget, cUnits, C.double(toMeters))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set the linear units for the target node and update all existing linear parameters
 func (sr SpatialReference) SetLinearUnitsAndUpdateParameters(name string, toMeters float64) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetLinearUnitsAndUpdateParameters(sr.cval, cName, C.double(toMeters))).Err()
+	cErr := C.OSRSetLinearUnitsAndUpdateParameters(sr.cval, cName, C.double(toMeters))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Fetch linear projection units
@@ -386,45 +411,51 @@ func (sr SpatialReference) IsSame(other SpatialReference) bool {
 func (sr SpatialReference) SetLocalCS(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetLocalCS(sr.cval, cName)).Err()
+	cErr := C.OSRSetLocalCS(sr.cval, cName)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set the user visible projected CS name
 func (sr SpatialReference) SetProjectedCS(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetProjCS(sr.cval, cName)).Err()
+	cErr := C.OSRSetProjCS(sr.cval, cName)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set the user visible geographic CS name
 func (sr SpatialReference) SetGeocentricCS(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetGeocCS(sr.cval, cName)).Err()
+	cErr := C.OSRSetGeocCS(sr.cval, cName)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set geographic CS based on well known name
 func (sr SpatialReference) SetWellKnownGeographicCS(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetWellKnownGeogCS(sr.cval, cName)).Err()
+	cErr := C.OSRSetWellKnownGeogCS(sr.cval, cName)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set spatial reference from various text formats
 func (sr SpatialReference) SetFromUserInput(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetFromUserInput(sr.cval, cName)).Err()
+	cErr := C.OSRSetFromUserInput(sr.cval, cName)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Copy geographic CS from another spatial reference
 func (sr SpatialReference) CopyGeographicCSFrom(other SpatialReference) error {
-	return OGRErr(C.OSRCopyGeogCSFrom(sr.cval, other.cval)).Err()
+	cErr := C.OSRCopyGeogCSFrom(sr.cval, other.cval)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set the Bursa-Wolf conversion to WGS84
 func (sr SpatialReference) SetTOWGS84(dx, dy, dz, ex, ey, ez, ppm float64) error {
-	return OGRErr(C.OSRSetTOWGS84(
+	cErr := C.OSRSetTOWGS84(
 		sr.cval,
 		C.double(dx),
 		C.double(dy),
@@ -433,12 +464,14 @@ func (sr SpatialReference) SetTOWGS84(dx, dy, dz, ex, ey, ez, ppm float64) error
 		C.double(ey),
 		C.double(ez),
 		C.double(ppm),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Fetch the TOWGS84 parameters if available
 func (sr SpatialReference) TOWGS84() (coeff [7]float64, err error) {
-	err = OGRErr(C.OSRGetTOWGS84(sr.cval, (*C.double)(unsafe.Pointer(&coeff[0])), 7)).Err()
+	cErr := C.OSRGetTOWGS84(sr.cval, (*C.double)(unsafe.Pointer(&coeff[0])), 7)
+	OGRErrContainer{ErrVal: cErr}.Err()
 	return
 }
 
@@ -449,7 +482,8 @@ func (sr SpatialReference) SetCompoundCS(
 ) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetCompoundCS(sr.cval, cName, horizontal.cval, vertical.cval)).Err()
+	cErr := C.OSRSetCompoundCS(sr.cval, cName, horizontal.cval, vertical.cval)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set geographic coordinate system
@@ -471,7 +505,7 @@ func (sr SpatialReference) SetGeographicCS(
 	defer C.free(unsafe.Pointer(cPMName))
 	cAngularUnits := C.CString(angularUnits)
 	defer C.free(unsafe.Pointer(cAngularUnits))
-	return OGRErr(C.OSRSetGeogCS(
+	cErr := C.OSRSetGeogCS(
 		sr.cval,
 		cGeogName,
 		cDatumName,
@@ -482,7 +516,8 @@ func (sr SpatialReference) SetGeographicCS(
 		C.double(offset),
 		cAngularUnits,
 		C.double(toRadians),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set up the vertical coordinate system
@@ -491,28 +526,29 @@ func (sr SpatialReference) SetVerticalCS(csName, datumName string, datumType int
 	defer C.free(unsafe.Pointer(cCSName))
 	cDatumName := C.CString(datumName)
 	defer C.free(unsafe.Pointer(cDatumName))
-	return OGRErr(C.OSRSetVertCS(sr.cval, cCSName, cDatumName, C.int(datumType))).Err()
+	cErr := C.OSRSetVertCS(sr.cval, cCSName, cDatumName, C.int(datumType))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Get spheroid semi-major axis
 func (sr SpatialReference) SemiMajorAxis() (float64, error) {
 	var cErr C.OGRErr
 	axis := C.OSRGetSemiMajor(sr.cval, &cErr)
-	return float64(axis), OGRErr(cErr).Err()
+	return float64(axis), OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Get spheroid semi-minor axis
 func (sr SpatialReference) SemiMinorAxis() (float64, error) {
 	var cErr C.OGRErr
 	axis := C.OSRGetSemiMinor(sr.cval, &cErr)
-	return float64(axis), OGRErr(cErr).Err()
+	return float64(axis), OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Get spheroid inverse flattening axis
 func (sr SpatialReference) InverseFlattening() (float64, error) {
 	var cErr C.OGRErr
 	flat := C.OSRGetInvFlattening(sr.cval, &cErr)
-	return float64(flat), OGRErr(cErr).Err()
+	return float64(flat), OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Sets the authority for a node
@@ -521,7 +557,8 @@ func (sr SpatialReference) SetAuthority(target, authority string, code int) erro
 	defer C.free(unsafe.Pointer(cTarget))
 	cAuthority := C.CString(authority)
 	defer C.free(unsafe.Pointer(cAuthority))
-	return OGRErr(C.OSRSetAuthority(sr.cval, cTarget, cAuthority, C.int(code))).Err()
+	cErr := C.OSRSetAuthority(sr.cval, cTarget, cAuthority, C.int(code))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Get the authority code for a node
@@ -544,14 +581,16 @@ func (sr SpatialReference) AuthorityName(target string) string {
 func (sr SpatialReference) SetProjectionByName(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetProjection(sr.cval, cName)).Err()
+	cErr := C.OSRSetProjection(sr.cval, cName)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set a projection parameter value
 func (sr SpatialReference) SetProjectionParameter(name string, value float64) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetProjParm(sr.cval, cName, C.double(value))).Err()
+	cErr := C.OSRSetProjParm(sr.cval, cName, C.double(value))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Fetch a projection parameter value
@@ -560,14 +599,15 @@ func (sr SpatialReference) ProjectionParameter(name string, defaultValue float64
 	defer C.free(unsafe.Pointer(cName))
 	var cErr C.OGRErr
 	value := C.OSRGetProjParm(sr.cval, cName, C.double(defaultValue), &cErr)
-	return float64(value), OGRErr(cErr).Err()
+	return float64(value), OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set a projection parameter with a normalized value
 func (sr SpatialReference) SetNormalizedProjectionParameter(name string, value float64) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetNormProjParm(sr.cval, cName, C.double(value))).Err()
+	cErr := C.OSRSetNormProjParm(sr.cval, cName, C.double(value))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Fetch a normalized projection parameter value
@@ -578,12 +618,13 @@ func (sr SpatialReference) NormalizedProjectionParameter(
 	defer C.free(unsafe.Pointer(cName))
 	var cErr C.OGRErr
 	value := C.OSRGetProjParm(sr.cval, cName, C.double(defaultValue), &cErr)
-	return float64(value), OGRErr(cErr).Err()
+	return float64(value), OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set UTM projection definition
 func (sr SpatialReference) SetUTM(zone int, north bool) error {
-	return OGRErr(C.OSRSetUTM(sr.cval, C.int(zone), BoolToCInt(north))).Err()
+	cErr := C.OSRSetUTM(sr.cval, C.int(zone), BoolToCInt(north))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Get UTM zone information
@@ -595,7 +636,8 @@ func (sr SpatialReference) UTMZone() (zone int, north bool) {
 
 // Set State Plane projection definition
 func (sr SpatialReference) SetStatePlane(zone int, nad83 bool) error {
-	return OGRErr(C.OSRSetStatePlane(sr.cval, C.int(zone), BoolToCInt(nad83))).Err()
+	cErr := C.OSRSetStatePlane(sr.cval, C.int(zone), BoolToCInt(nad83))
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set State Plane projection definition
@@ -607,18 +649,20 @@ func (sr SpatialReference) SetStatePlaneWithUnits(
 ) error {
 	cUnitName := C.CString(unitName)
 	defer C.free(unsafe.Pointer(cUnitName))
-	return OGRErr(C.OSRSetStatePlaneWithUnits(
+	cErr := C.OSRSetStatePlaneWithUnits(
 		sr.cval,
 		C.int(zone),
 		BoolToCInt(nad83),
 		cUnitName,
 		C.double(factor),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set EPSG authority info if possible
 func (sr SpatialReference) AutoIdentifyEPSG() error {
-	return OGRErr(C.OSRAutoIdentifyEPSG(sr.cval)).Err()
+	cErr := C.OSRAutoIdentifyEPSG(sr.cval)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Return true if EPSG feels this coordinate system should be treated as having lat/long coordinate ordering
@@ -634,7 +678,7 @@ func (sr SpatialReference) EPSGTreatsAsLatLong() bool {
 func (sr SpatialReference) SetACEA(
 	stdp1, stdp2, centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetACEA(
+	cErr := C.OSRSetACEA(
 		sr.cval,
 		C.double(stdp1),
 		C.double(stdp2),
@@ -642,58 +686,63 @@ func (sr SpatialReference) SetACEA(
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Azimuthal Equidistant
 func (sr SpatialReference) SetAE(centerLat, centerLong, falseEasting, falseNorthing float64) error {
-	return OGRErr(C.OSRSetAE(
+	cErr := C.OSRSetAE(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Bonne
 func (sr SpatialReference) SetBonne(standardParallel, centralMeridian, falseEasting, falseNorthing float64) error {
-	return OGRErr(C.OSRSetBonne(
+	cErr := C.OSRSetBonne(
 		sr.cval,
 		C.double(standardParallel),
 		C.double(centralMeridian),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Cylindrical Equal Area
 func (sr SpatialReference) SetCEA(stdp1, centralMeridian, falseEasting, falseNorthing float64) error {
-	return OGRErr(C.OSRSetCEA(
+	cErr := C.OSRSetCEA(
 		sr.cval,
 		C.double(stdp1),
 		C.double(centralMeridian),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Cassini-Soldner
 func (sr SpatialReference) SetCS(centerLat, centerLong, falseEasting, falseNorthing float64) error {
-	return OGRErr(C.OSRSetCS(
+	cErr := C.OSRSetCS(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Equidistant Conic
 func (sr SpatialReference) SetEC(
 	stdp1, stdp2, centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetEC(
+	cErr := C.OSRSetEC(
 		sr.cval,
 		C.double(stdp1),
 		C.double(stdp2),
@@ -701,117 +750,127 @@ func (sr SpatialReference) SetEC(
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Eckert I-VI
 func (sr SpatialReference) SetEckert(variation int, centralMeridian, falseEasting, falseNorthing float64) error {
-	return OGRErr(C.OSRSetEckert(
+	cErr := C.OSRSetEckert(
 		sr.cval,
 		C.int(variation),
 		C.double(centralMeridian),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Equirectangular
 func (sr SpatialReference) SetEquirectangular(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetEquirectangular(
+	cErr := C.OSRSetEquirectangular(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Equirectangular (generalized form)
 func (sr SpatialReference) SetEquirectangularGeneralized(
 	centerLat, centerLong, psuedoStdParallel, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetEquirectangular2(
+	cErr := C.OSRSetEquirectangular2(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(psuedoStdParallel),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Gall Stereographic
 func (sr SpatialReference) SetGS(centralMeridian, falseEasting, falseNorthing float64) error {
-	return OGRErr(C.OSRSetGS(
+	cErr := C.OSRSetGS(
 		sr.cval,
 		C.double(centralMeridian),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Goode Homolosine
 func (sr SpatialReference) SetGH(centralMeridian, falseEasting, falseNorthing float64) error {
-	return OGRErr(C.OSRSetGH(
+	cErr := C.OSRSetGH(
 		sr.cval,
 		C.double(centralMeridian),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Interrupted Goode Homolosine
 func (sr SpatialReference) SetIGH() error {
-	return OGRErr(C.OSRSetIGH(sr.cval)).Err()
+	cErr := C.OSRSetIGH(sr.cval)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to GEOS - Geostationary Satellite View
 func (sr SpatialReference) SetGEOS(
 	centralMeridian, satelliteHeight, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetGEOS(
+	cErr := C.OSRSetGEOS(
 		sr.cval,
 		C.double(centralMeridian),
 		C.double(satelliteHeight),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Gauss Schreiber Transverse Mercator
 func (sr SpatialReference) SetGSTM(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetGaussSchreiberTMercator(
+	cErr := C.OSRSetGaussSchreiberTMercator(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to gnomonic
 func (sr SpatialReference) SetGnomonic(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetGnomonic(
+	cErr := C.OSRSetGnomonic(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Hotine Oblique Mercator projection using azimuth angle
 func (sr SpatialReference) SetHOM(
 	centerLat, centerLong, azimuth, rectToSkew, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetHOM(
+	cErr := C.OSRSetHOM(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
@@ -820,14 +879,15 @@ func (sr SpatialReference) SetHOM(
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Hotine Oblique Mercator projection using two points on projection centerline
 func (sr SpatialReference) SetHOM2PNO(
 	centerLat, lat1, long1, lat2, long2, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetHOM2PNO(
+	cErr := C.OSRSetHOM2PNO(
 		sr.cval,
 		C.double(centerLat),
 		C.double(lat1),
@@ -837,28 +897,30 @@ func (sr SpatialReference) SetHOM2PNO(
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to International Map of the World Polyconic
 func (sr SpatialReference) SetIWMPolyconic(
 	lat1, lat2, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetIWMPolyconic(
+	cErr := C.OSRSetIWMPolyconic(
 		sr.cval,
 		C.double(lat1),
 		C.double(lat2),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Krovak Oblique Conic Conformal
 func (sr SpatialReference) SetKrovak(
 	centerLat, centerLong, azimuth, psuedoStdParallel, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetKrovak(
+	cErr := C.OSRSetKrovak(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
@@ -867,27 +929,29 @@ func (sr SpatialReference) SetKrovak(
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Lambert Azimuthal Equal Area
 func (sr SpatialReference) SetLAEA(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetLAEA(
+	cErr := C.OSRSetLAEA(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Lambert Conformal Conic
 func (sr SpatialReference) SetLCC(
 	stdp1, stdp2, centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetLCC(
+	cErr := C.OSRSetLCC(
 		sr.cval,
 		C.double(stdp1),
 		C.double(stdp2),
@@ -895,28 +959,30 @@ func (sr SpatialReference) SetLCC(
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Lambert Conformal Conic (1 standard parallel)
 func (sr SpatialReference) SetLCC1SP(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetLCC1SP(
+	cErr := C.OSRSetLCC1SP(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Lambert Conformal Conic (Belgium)
 func (sr SpatialReference) SetLCCB(
 	stdp1, stdp2, centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetLCCB(
+	cErr := C.OSRSetLCCB(
 		sr.cval,
 		C.double(stdp1),
 		C.double(stdp2),
@@ -924,178 +990,192 @@ func (sr SpatialReference) SetLCCB(
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Miller Cylindrical
 func (sr SpatialReference) SetMC(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetMC(
+	cErr := C.OSRSetMC(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Mercator
 func (sr SpatialReference) SetMercator(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetMercator(
+	cErr := C.OSRSetMercator(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set tp Mollweide
 func (sr SpatialReference) SetMollweide(
 	centralMeridian, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetMollweide(
+	cErr := C.OSRSetMollweide(
 		sr.cval,
 		C.double(centralMeridian),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to New Zealand Map Grid
 func (sr SpatialReference) SetNZMG(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetNZMG(
+	cErr := C.OSRSetNZMG(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Oblique Stereographic
 func (sr SpatialReference) SetOS(
 	originLat, meridian, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetOS(
+	cErr := C.OSRSetOS(
 		sr.cval,
 		C.double(originLat),
 		C.double(meridian),
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Orthographic
 func (sr SpatialReference) SetOrthographic(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetOrthographic(
+	cErr := C.OSRSetOrthographic(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Polyconic
 func (sr SpatialReference) SetPolyconic(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetPolyconic(
+	cErr := C.OSRSetPolyconic(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Polar Stereographic
 func (sr SpatialReference) SetPS(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetPS(
+	cErr := C.OSRSetPS(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Robinson
 func (sr SpatialReference) SetRobinson(
 	centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetRobinson(
+	cErr := C.OSRSetRobinson(
 		sr.cval,
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Sinusoidal
 func (sr SpatialReference) SetSinusoidal(
 	centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetSinusoidal(
+	cErr := C.OSRSetSinusoidal(
 		sr.cval,
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Stereographic
 func (sr SpatialReference) SetStereographic(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetStereographic(
+	cErr := C.OSRSetStereographic(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Swiss Oblique Cylindrical
 func (sr SpatialReference) SetSOC(
 	latitudeOfOrigin, centralMeridian, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetSOC(
+	cErr := C.OSRSetSOC(
 		sr.cval,
 		C.double(latitudeOfOrigin),
 		C.double(centralMeridian),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Transverse Mercator
 func (sr SpatialReference) SetTM(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetTM(
+	cErr := C.OSRSetTM(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Transverse Mercator variant
@@ -1104,7 +1184,7 @@ func (sr SpatialReference) SetTMVariant(
 ) error {
 	cName := C.CString(variantName)
 	defer C.free(unsafe.Pointer(cName))
-	return OGRErr(C.OSRSetTMVariant(
+	cErr := C.OSRSetTMVariant(
 		sr.cval,
 		cName,
 		C.double(centerLat),
@@ -1112,46 +1192,50 @@ func (sr SpatialReference) SetTMVariant(
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Tunisia Mining Grid
 func (sr SpatialReference) SetTMG(
 	centerLat, centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetTMG(
+	cErr := C.OSRSetTMG(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to Transverse Mercator (South Oriented)
 func (sr SpatialReference) SetTMSO(
 	centerLat, centerLong, scale, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetTMSO(
+	cErr := C.OSRSetTMSO(
 		sr.cval,
 		C.double(centerLat),
 		C.double(centerLong),
 		C.double(scale),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Set to VanDerGrinten
 func (sr SpatialReference) SetVDG(
 	centerLong, falseEasting, falseNorthing float64,
 ) error {
-	return OGRErr(C.OSRSetVDG(
+	cErr := C.OSRSetVDG(
 		sr.cval,
 		C.double(centerLong),
 		C.double(falseEasting),
 		C.double(falseNorthing),
-	)).Err()
+	)
+	return OGRErrContainer{ErrVal: cErr}.Err()
 }
 
 // Cleanup cached SRS related memory


### PR DESCRIPTION
## Issue: the Err() function in gdal.go attempts to define new methods on C.CPLErr and C.OGRErr

note: this error occurs for go v1.21.0

My company's software uses this package, however our backend fails to build with the latest version v0.0.0-20230422025444-05e99f726ff9. The error received when building our go service is this:

```
../../go/pkg/mod/github.com/lukeroth/gdal@v0.0.0-20230422025444-05e99f726ff9/gdal.go:44:11: cannot define new methods on non-local type C.CPLErr
../../go/pkg/mod/github.com/lukeroth/gdal@v0.0.0-20230422025444-05e99f726ff9/gdal.go:60:11: cannot define new methods on non-local type C.OGRErr
```

### Resolution:
created a wrapper struct for the C.CPLErr and C.OGRErr

`type CPLErrContainer struct {
	ErrVal C.CPLErr
}`

`type OGRErrContainer struct {
	ErrVal C.OGRErr
}`

### Changes:
corrected 4 files to implement the new Error types
1. ogr.go
2. osr.go
3. gdal.go
4. algorithms.go

### Results:
our backend now builds correctly and there are no gdal errors thrown during the build. Tested our code still performs as expected via Postman