### PR TITLE
Demprocessing allow empty string for colorfile to represent "no input" allowing users to use the hillshade option which currently fails

### DIFF
--- a/utilities.go
+++ b/utilities.go
@@ -269,8 +269,12 @@ func DEMProcessing(dstDS string, sourceDS Dataset, processing string, colorFileN
 
 	cprocessing := C.CString(processing)
 	defer C.free(unsafe.Pointer(cprocessing))
-	ccolorFileName := C.CString(colorFileName)
-	defer C.free(unsafe.Pointer(ccolorFileName))
+	var ccolorFileName *C.char
+	if colorFileName == "" {
+		ccolorFileName = C.CString(colorFileName)
+		defer C.free(unsafe.Pointer(ccolorFileName))
+	}
+
 	ds := C.GDALDEMProcessing(cdstDS,
 		sourceDS.cval,
 		cprocessing,


### PR DESCRIPTION
The current behaviour of Demprocessing does not allow for creating hillshades as passing colorFile as a parameter when running the hillshade algorithm causes an error from gdal. The same might be the case for slope and aspect, but isn't tested. 

This PR allows for passing an empty string to be evaluated as no input which i find to be the most intuitive way to skip the input with minimal refactoring. 

The different algorithms that gdaldem can run is listed here: 
https://gdal.org/programs/gdaldem.html
