### PR TITLE
Add CPLErrContainer wrapper for ContourGenerate

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -309,7 +309,7 @@ func (src RasterBand) ContourGenerate(
 		fixedLevels_p = (*C.double)(unsafe.Pointer(&fixedLevels[0]))
 	}
 
-	return CPLErr(C.GDALContourGenerate(
+	cErr := C.GDALContourGenerate(
 		src.cval,
 		C.double(interval),
 		C.double(base),
@@ -322,7 +322,8 @@ func (src RasterBand) ContourGenerate(
 		C.int(elevationFieldIndex),
 		C.goGDALProgressFuncProxyB(),
 		unsafe.Pointer(arg),
-	)).Err()
+	)
+	return CPLErrContainer{ErrVal: cErr}.Err()
 }
 
 /* --------------------------------------------- */


### PR DESCRIPTION
Recent update with new func `ContourGenerate` resulted in build errors on new versions of go.

```bash
github.com/lukeroth/gdal/algorithms.go:325:3: CPLErr(func() _Ctype_CPLErr {…}()).Err undefined (type CPLErr has no field or method Err)
```

This problem is related to #90 and was fixed in #92. Nevertheless `ContourGenerate` was using old format which caused some troubles.