### PR TITLE
fix(utilities): reject empty sourceDS in BuildVRT/Warp/VectorTranslate

### DIFF
--- a/utilities.go
+++ b/utilities.go
@@ -51,6 +51,9 @@ func Info(sourceDS Dataset, options []string) string {
 }
 
 func BuildVRT(dstDS string, sourceDS []Dataset, srcDSFilePath, options []string) (Dataset, error) {
+	if len(sourceDS) == 0 {
+		return Dataset{}, fmt.Errorf("BuildVRT: sourceDS must not be empty")
+	}
 	if dstDS == "" {
 		dstDS = "MEM:::"
 		if !stringArrayContains(options, "-of") {
@@ -103,6 +106,9 @@ func BuildVRT(dstDS string, sourceDS []Dataset, srcDSFilePath, options []string)
 }
 
 func Warp(dstDS string, destDS *Dataset, sourceDS []Dataset, options []string) (Dataset, error) {
+	if len(sourceDS) == 0 {
+		return Dataset{}, fmt.Errorf("Warp: sourceDS must not be empty")
+	}
 	if dstDS == "" && destDS == nil {
 		dstDS = "MEM:::"
 		if !stringArrayContains(options, "-of") {
@@ -176,6 +182,9 @@ func Translate(dstDS string, sourceDS Dataset, options []string) (Dataset, error
 }
 
 func VectorTranslate(dstDS string, sourceDS []Dataset, options []string) (Dataset, error) {
+	if len(sourceDS) == 0 {
+		return Dataset{}, fmt.Errorf("VectorTranslate: sourceDS must not be empty")
+	}
 	if dstDS == "" {
 		dstDS = "MEM:::"
 		if !stringArrayContains(options, "-f") {


### PR DESCRIPTION
Fixes lukeroth/gdal#112.

## Problem

`BuildVRT`, `Warp`, and `VectorTranslate` each construct `srcDS` from a caller-supplied `[]Dataset` and then unconditionally take the address of `srcDS[0]` to pass into the GDAL C API. If `sourceDS` is empty, trivially reachable when callers build the slice dynamically and filter all entries out, `&srcDS[0]` panics with `index out of range` before the Cgo call runs.

## Fix

Bail out early with a descriptive error naming the function. Happy path and non-empty inputs are unchanged.

## Test

`gofmt` clean. The repository requires a GDAL system library for full `go test` and can't be fully exercised on this machine, but the length-guard logic is trivial and self-contained.