### PR TITLE
fix for deprecated GDALGetDataTypeSize()

### DIFF
--- a/gdal.go
+++ b/gdal.go
@@ -236,7 +236,7 @@ const (
 
 // Get data type size in bits.
 func (dataType DataType) Size() int {
-	return int(C.GDALGetDataTypeSize(C.GDALDataType(dataType)))
+	return int(C.goGDALGetDataTypeSizeCompat(C.GDALDataType(dataType)))
 }
 
 func (dataType DataType) IsComplex() int {

--- a/go_gdal.c
+++ b/go_gdal.c
@@ -21,4 +21,12 @@ GDALProgressFunc goGDALProgressFuncProxyB() {
 	return goGDALProgressFuncProxyB_;
 }
 
+int goGDALGetDataTypeSizeCompat(GDALDataType dataType) {
+#if GDAL_VERSION_MAJOR >= 3
+	return GDALGetDataTypeSizeBits(dataType);
+#else
+	return GDALGetDataTypeSize(dataType);
+#endif
+}
+
 

--- a/go_gdal.h
+++ b/go_gdal.h
@@ -15,6 +15,9 @@
 // transform GDALProgressFunc to go func
 GDALProgressFunc goGDALProgressFuncProxyB();
 
+// Compatibility wrapper for GDAL data type size API changes.
+int goGDALGetDataTypeSizeCompat(GDALDataType dataType);
+
 #endif // GO_GDAL_H_
 
 


### PR DESCRIPTION
For GDAL Version >= 3 the new `GDALGetDataTypeSizeBits()` is used instead. 
Fixes #111 
